### PR TITLE
Point flavor safety page at external site

### DIFF
--- a/src/components/header.js
+++ b/src/components/header.js
@@ -39,7 +39,11 @@ const Header = ({ siteTitle }) => (
           <NavDropdown.Item as={Link} to="/safety/nicotine">
             Nicotine Handling/Storage
           </NavDropdown.Item>
-          <NavDropdown.Item as={Link} to="/safety/flavors">
+          <NavDropdown.Item
+            href="https://safety.diyejuice.org/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             Flavors of Concern
           </NavDropdown.Item>
         </NavDropdown>


### PR DESCRIPTION
The flavor safety code is currently being hosted at https://safety.diyejuice.org - this PR updates the nav to point the Flavors of Concern link to that location instead.